### PR TITLE
export HTTPClient interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,8 +22,8 @@ type Caller interface {
 	Call(ctx context.Context, method, path string, headers map[string]string, reqObj interface{}, respObj interface{}) error
 }
 
-// httpClient is internal interface fot HTTP client. Built-in net/http.Client implements this interface as well.
-type httpClient interface {
+// HTTPClient is interface fot HTTP client. Built-in net/http.Client implements this interface as well.
+type HTTPClient interface {
 	Do(r *http.Request) (*http.Response, error)
 }
 
@@ -32,7 +32,7 @@ type Option func(*Client)
 
 // Client contains API parameters and provides set of API entity clients.
 type Client struct {
-	httpClient httpClient
+	httpClient HTTPClient
 	appID      string
 	privateKey string
 	env        env
@@ -74,7 +74,7 @@ func New(options ...Option) *Client {
 }
 
 // OptHTTPClient returns option with given HTTP client.
-func OptHTTPClient(httpClient httpClient) Option {
+func OptHTTPClient(httpClient HTTPClient) Option {
 	return func(c *Client) {
 		c.httpClient = httpClient
 	}


### PR DESCRIPTION
`HTTPClient` interface must be exported because it's the part of public API. 

<img width="541" alt="screen shot 2017-07-18 at 23 59 34" src="https://user-images.githubusercontent.com/864369/28339587-39f7d250-6c15-11e7-9f99-f5e8511149e5.png">

So from godoc it's impossible to understand what should I pass.