### PR TITLE
 Webhooks support

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -31,13 +31,19 @@ type Authorization struct {
 
 // AuthorizationParams is a set of params for creating entity.
 type AuthorizationParams struct {
-	PaymentMethod          PaymentMethodDetails    `json:"payment_method"`
-	MerchantSiteURL        string                  `json:"merchant_site_url,omitempty"`
-	ReconciliationID       string                  `json:"reconciliation_id,omitempty"`
-	ThreeDSecureAttributes *ThreeDSecureAttributes `json:"three_d_secure_attributes,omitempty"`
-	Installments           *Installments           `json:"installments,omitempty"`
-	ProviderSpecificData   map[string]interface{}  `json:"provider_specific_data,omitempty"`
-	AdditionalDetails      map[string]interface{}  `json:"additional_details,omitempty"`
+	PaymentMethod            PaymentMethodDetails      `json:"payment_method"`
+	MerchantSiteURL          string                    `json:"merchant_site_url,omitempty"`
+	ReconciliationID         string                    `json:"reconciliation_id,omitempty"`
+	ThreeDSecureAttributes   *ThreeDSecureAttributes   `json:"three_d_secure_attributes,omitempty"`
+	Installments             *Installments             `json:"installments,omitempty"`
+	ProviderSpecificData     map[string]interface{}    `json:"provider_specific_data,omitempty"`
+	AdditionalDetails        map[string]interface{}    `json:"additional_details,omitempty"`
+	COFTransactionIndicators *COFTransactionIndicators `json:"cof_transaction_indicators,omitempty"`
+}
+
+type COFTransactionIndicators struct {
+	CardEntryMode           string `json:"card_entry_mode"`
+	COFConsentTransactionID string `json:"cof_consent_transaction_id"`
 }
 
 // New creates new Authorization entity.

--- a/authorization.go
+++ b/authorization.go
@@ -37,7 +37,7 @@ type AuthorizationParams struct {
 	ThreeDSecureAttributes   *ThreeDSecureAttributes   `json:"three_d_secure_attributes,omitempty"`
 	Installments             *Installments             `json:"installments,omitempty"`
 	ProviderSpecificData     map[string]interface{}    `json:"provider_specific_data,omitempty"`
-	AdditionalDetails        map[string]interface{}    `json:"additional_details,omitempty"`
+	AdditionalDetails        map[string]string         `json:"additional_details,omitempty"`
 	COFTransactionIndicators *COFTransactionIndicators `json:"cof_transaction_indicators,omitempty"`
 }
 

--- a/authorization.go
+++ b/authorization.go
@@ -37,6 +37,7 @@ type AuthorizationParams struct {
 	ThreeDSecureAttributes *ThreeDSecureAttributes `json:"three_d_secure_attributes,omitempty"`
 	Installments           *Installments           `json:"installments,omitempty"`
 	ProviderSpecificData   map[string]interface{}  `json:"provider_specific_data,omitempty"`
+	AdditionalDetails      map[string]interface{}  `json:"additional_details,omitempty"`
 }
 
 // New creates new Authorization entity.

--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -34,6 +35,7 @@ type Option func(*Client)
 // Client contains API parameters and provides set of API entity clients.
 type Client struct {
 	httpClient HTTPClient
+	apiURL     string
 	appID      string
 	privateKey string
 	env        env
@@ -43,7 +45,9 @@ type env string
 
 const (
 	apiVersion = "1.2.0"
-	apiURL     = "https://api.paymentsos.com/"
+
+	// ApiURL is default base url to send requests. It May be changed with OptApiURL
+	ApiURL = "https://api.paymentsos.com"
 
 	// EnvTest is a value for test environment header
 	EnvTest env = "test"
@@ -64,11 +68,16 @@ const (
 func New(options ...Option) *Client {
 	c := &Client{
 		httpClient: http.DefaultClient,
+		apiURL:     ApiURL,
 		env:        EnvTest,
 	}
 
 	for _, option := range options {
 		option(c)
+	}
+
+	if !strings.HasSuffix(c.apiURL, "/") {
+		c.apiURL = c.apiURL + "/"
 	}
 
 	return c
@@ -78,6 +87,13 @@ func New(options ...Option) *Client {
 func OptHTTPClient(httpClient HTTPClient) Option {
 	return func(c *Client) {
 		c.httpClient = httpClient
+	}
+}
+
+// OptApiURL returns option with given API URL.
+func OptApiURL(apiURL string) Option {
+	return func(c *Client) {
+		c.apiURL = apiURL
 	}
 }
 
@@ -115,7 +131,7 @@ func (c *Client) Call(ctx context.Context, method, path string, headers map[stri
 		reqBody = bytes.NewBuffer(reqBodyBytes)
 	}
 
-	req, err := http.NewRequest(method, apiURL+path, reqBody)
+	req, err := http.NewRequest(method, c.apiURL+path, reqBody)
 	if err != nil {
 		return errors.Wrap(err, "failed to create HTTP request")
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,220 @@
+package zooz
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const headerEventType = "event-type"
+
+type Callback interface {
+	isCallback()
+}
+
+type CallbackCommon struct {
+	EventType      string `json:"-"` // The type of resource that triggered the event. For example, "payment.authorization.create". Returned in "event-type" header.
+	XPaymentsOSEnv string `json:"-"` // PaymentsOS environment, 'live' or 'test'. Returned in "x-payments-os-env" header.
+	XZoozRequestID string `json:"-"` // The ID of the original request that triggered the webhook event. Returned in "x-zooz-request-id" header.
+
+	ID        string    `json:"id"`      // The Webhook id. This id is unique per Webhook and can be used to validate that the request is unique.
+	Created   time.Time `json:"created"` // The date and time the event was created. "2018-10-03T04:58:35.385Z".
+	AccountID string    `json:"account_id"`
+	AppID     string    `json:"app_id"`
+	PaymentID string    `json:"payment_id"`
+}
+
+func (CallbackCommon) isCallback() {}
+
+type PaymentCallback struct {
+	CallbackCommon
+	Data Payment `json:"data"`
+}
+
+type AuthorizationCallback struct {
+	CallbackCommon
+	Data Authorization `json:"data"`
+}
+
+type CaptureCallback struct {
+	CallbackCommon
+	Data Capture `json:"data"`
+}
+
+type VoidCallback struct {
+	CallbackCommon
+	Data Void `json:"data"`
+}
+
+type RefundCallback struct {
+	CallbackCommon
+	Data Refund `json:"data"`
+}
+
+type privateKeyProvider interface {
+	// PrivateKey should return private key for given business unit. It is used to validate request signature.
+	// For unknown business units (including empty appID) it should return (nil, nil).
+	PrivateKey(appID string) ([]byte, error)
+}
+
+type PrivateKeyProviderFunc func(appID string) ([]byte, error)
+
+func (f PrivateKeyProviderFunc) PrivateKey(appID string) ([]byte, error) { return f(appID) }
+
+type ErrBadRequest struct {
+	Err error
+}
+
+func (e ErrBadRequest) Error() string { return e.Err.Error() }
+
+func (e ErrBadRequest) Unwrap() error { return e.Err }
+
+// DecodeWebhookRequest can be used to decode incoming webhook request from PaymentsOS.
+// Supports webhook version >= 1.2.0
+//
+// Will return ErrBadRequest if the error is permanent and request should not be retried.
+// Bear in mind that your webhook handler should respond with 2xx status code anyway, otherwise PaymentsOS will continue
+// resending this request.
+// ErrBadRequest errors include:
+// 	* wrong body format (broken/invalid json, ...)
+//  * validation error (missing required fields or headers, unexpected values)
+// 	* unknown business unit (app_id)
+//  * request signature validation error
+func DecodeWebhookRequest(_ context.Context, r *http.Request, keyProvider privateKeyProvider) (Callback, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read request body")
+	}
+
+	// Validate request signature
+	signature, err := calculateWebhookSignature(keyProvider, body, r.Header)
+	if err != nil {
+		return nil, errors.WithMessage(err, "calculate request signature")
+	}
+	if "sig1="+signature != r.Header.Get("signature") {
+		return nil, ErrBadRequest{errors.New("incorrect signature")}
+	}
+
+	// Decode request into appropriate entity type based on "event-type" header
+	eventType := r.Header.Get(headerEventType)
+	common := CallbackCommon{
+		EventType:      eventType,
+		XPaymentsOSEnv: r.Header.Get("x-payments-os-env"),
+		XZoozRequestID: r.Header.Get("x-zooz-request-id"),
+	}
+	var cbRef Callback
+	switch true {
+	case strings.HasPrefix(eventType, "payment.payment."): // @TODO: event-type format is not documented, this is my guess. Validate in zooz sandbox!
+		cbRef = &PaymentCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.authorization."):
+		cbRef = &AuthorizationCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.capture."):
+		cbRef = &CaptureCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.void."):
+		cbRef = &VoidCallback{CallbackCommon: common}
+	case strings.HasPrefix(eventType, "payment.refund."):
+		cbRef = &RefundCallback{CallbackCommon: common}
+	default:
+		return nil, ErrBadRequest{errors.Errorf("unsupported event type: %q", eventType)}
+	}
+
+	if err := json.Unmarshal(body, cbRef); err != nil {
+		return nil, errors.Wrapf(err, "unmarshal request body into entity of type %T", cbRef)
+	}
+	return deref(cbRef), nil
+}
+
+// Calculates webhook request signature (without "sig1=" prefix).
+// reqBody should be a raw webhook request body, eventType should be the value of "event-type" request header.
+// Used by DecodeWebhookRequest.
+func calculateWebhookSignature(keyProvider privateKeyProvider, reqBody []byte, reqHeader http.Header) (string, error) {
+	type signatureFields struct {
+		ID        string `json:"id"`
+		Created   string `json:"created"`
+		AccountID string `json:"account_id"`
+		AppID     string `json:"app_id"`
+		PaymentID string `json:"payment_id"`
+		Data      struct {
+			ID     string `json:"id"`
+			Result struct {
+				Status      string `json:"status"`
+				Category    string `json:"category"`
+				SubCategory string `json:"sub_category"`
+			} `json:"result"`
+			ProviderData struct {
+				ResponseCode string `json:"response_code"`
+			} `json:"provider_data"`
+			ReconciliationID string `json:"reconciliation_id"`
+			Amount           *int64 `json:"amount"` // @TODO: should missing amount be zero or an empty string? Test for voids!
+			Currency         string `json:"currency"`
+		} `json:"data"`
+	}
+
+	f := signatureFields{}
+	if err := json.Unmarshal(reqBody, &f); err != nil {
+		return "", ErrBadRequest{errors.Wrapf(err, "unmarshal request body into entity of type %T", f)}
+	}
+
+	key, err := keyProvider.PrivateKey(f.AppID)
+	if err != nil {
+		return "", errors.Wrap(err, "select private key by app_id")
+	}
+	if key == nil {
+		return "", ErrBadRequest{errors.Errorf("unknown app_id %q", f.AppID)}
+	}
+
+	var amount string
+	if f.Data.Amount != nil {
+		amount = strconv.FormatInt(*f.Data.Amount, 10)
+	} else {
+		amount = ""
+	}
+	values := []string{
+		reqHeader.Get(headerEventType),
+		f.ID,
+		f.AccountID,
+		f.PaymentID,
+		f.Created,
+		f.AppID,
+		f.Data.ID,
+		f.Data.Result.Status,
+		f.Data.Result.Category,
+		f.Data.Result.SubCategory,
+		f.Data.ProviderData.ResponseCode,
+		f.Data.ReconciliationID,
+		amount,
+		f.Data.Currency,
+	}
+	mac := hmac.New(sha256.New, key)
+	if _, err := mac.Write([]byte(strings.Join(values, ","))); err != nil {
+		return "", errors.Wrap(err, "sha256 calculation") // should never happen since sha256.digest::Write() never returns error
+	}
+	sha := hex.EncodeToString(mac.Sum(nil))
+	return sha, nil
+}
+
+func deref(cb Callback) Callback {
+	switch cb := cb.(type) {
+	case *PaymentCallback:
+		return *cb
+	case *AuthorizationCallback:
+		return *cb
+	case *CaptureCallback:
+		return *cb
+	case *VoidCallback:
+		return *cb
+	case *RefundCallback:
+		return *cb
+	default:
+		panic("should be a pointer to a known callback type")
+	}
+}

--- a/webhook_exports_test.go
+++ b/webhook_exports_test.go
@@ -1,0 +1,18 @@
+package zooz
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func WebhookRequestSignature(t *testing.T, keyProvider privateKeyProvider, reqBody []byte, reqHeader http.Header) string {
+	signature, err := calculateWebhookSignature(keyProvider, reqBody, reqHeader)
+	require.NoError(t, err)
+	return "sig1=" + signature
+}
+
+func CalculateWebhookSignature(keyProvider privateKeyProvider, reqBody []byte, reqHeader http.Header) (string, error) {
+	return calculateWebhookSignature(keyProvider, reqBody, reqHeader)
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,728 @@
+package zooz_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gtforge/go-zooz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeWebhookRequest_Payment(t *testing.T) {
+	const eventType = "payment.payment.create" // @TODO: validate against real Zooz!
+	const privateKey = "test-private-key"
+
+	expected := zooz.PaymentCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 04, 58, 35, 385000000, time.UTC), // "2018-10-03T04:58:35.385Z"
+			AccountID: "test-account-id",
+			AppID:     "t",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Payment{
+			ID: "test-transaction-id",
+			PaymentParams: zooz.PaymentParams{
+				Amount:     1000,
+				Currency:   "USD",
+				CustomerID: "test-customer-id",
+			},
+			Status: zooz.PaymentStatusAuthorized,
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T04:58:35.385Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+		"status": "` + string(expected.Data.Status) + `",
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+		"currency":"` + expected.Data.Currency + `",
+		"customer_id": "` + expected.Data.CustomerID + `"
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", zooz.WebhookRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Authorization(t *testing.T) {
+	const eventType = "payment.authorization.create"
+	const privateKey = "test-private-key"
+
+	expected := zooz.AuthorizationCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 04, 58, 35, 385000000, time.UTC), // "2018-10-03T04:58:35.385Z"
+			AccountID: "test-account-id",
+			AppID:     "test-app-id",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Authorization{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			Amount:           1000,
+			ReconciliationID: "test-reconciliation-id",
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T04:58:35.385Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", zooz.WebhookRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Capture(t *testing.T) {
+	const eventType = "payment.capture.update"
+	const privateKey = "test-private-key"
+
+	expected := zooz.CaptureCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 05, 14, 17, 196000000, time.UTC), // "2018-10-03T05:14:17.196Z"
+			AccountID: "test-account-id",
+			AppID:     "test-app-id",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Capture{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			CaptureParams: zooz.CaptureParams{
+				ReconciliationID: "test-reconciliation-id",
+				Amount:           2000,
+			},
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", zooz.WebhookRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Void(t *testing.T) {
+	const eventType = "payment.void.create"
+	const privateKey = "test-private-key"
+
+	expected := zooz.VoidCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 05, 14, 17, 196000000, time.UTC), // "2018-10-03T05:14:17.196Z"
+			AccountID: "test-account-id",
+			AppID:     "test-app-id",
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Void{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(appID string) ([]byte, error) {
+		require.Equal(t, expected.AppID, appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T05:14:17.196Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", zooz.WebhookRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestDecodeWebhookRequest_Refund(t *testing.T) {
+	const eventType = "payment.refund.update"
+	const appID = "test-app-id"
+	const privateKey = "test-private-key"
+
+	expected := zooz.RefundCallback{
+		CallbackCommon: zooz.CallbackCommon{
+			EventType:      eventType,
+			XPaymentsOSEnv: "live",
+			XZoozRequestID: "test-x-zooz-request-id",
+
+			ID:        "test-webhook-id",
+			Created:   time.Date(2018, 10, 03, 05, 22, 45, 610000000, time.UTC), // "2018-10-03T05:22:45.610Z"
+			AccountID: "test-account-id",
+			AppID:     appID,
+			PaymentID: "test-payment-id",
+		},
+		Data: zooz.Refund{
+			ID: "test-transaction-id",
+			Result: zooz.Result{
+				Status:      "Pending",
+				Category:    "payment_method_declined",
+				SubCategory: "declined_by_issuing_bank",
+				Description: "The transaction was declined by the Issuing bank.",
+			},
+			RefundParams: zooz.RefundParams{
+				ReconciliationID: "test-reconciliation-id",
+				Amount:           2000,
+				CaptureID:        "test-capture-id",
+				Reason:           "reason for the refund",
+			},
+			ProviderData: zooz.ProviderData{
+				ProviderName: "test-provider-name",
+				ResponseCode: "test-response-code",
+			},
+		},
+	}
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(appID string) ([]byte, error) {
+		require.Equal(t, "test-app-id", appID)
+		return []byte(privateKey), nil
+	})
+
+	body :=
+		`{
+	"id": "` + expected.ID + `",
+    "created": "2018-10-03T05:22:45.610Z",
+    "account_id": "` + expected.AccountID + `",
+    "app_id": "` + expected.AppID + `",
+    "payment_id": "` + expected.PaymentID + `",
+	"data": {
+		"id": "` + expected.Data.ID + `",
+  		"result": {
+			"status": "` + expected.Data.Result.Status + `",
+    		"category": "` + expected.Data.Result.Category + `",
+    		"sub_category": "` + expected.Data.Result.SubCategory + `",
+    		"description": "` + expected.Data.Result.Description + `"
+  		},
+  		"amount": ` + strconv.FormatInt(expected.Data.Amount, 10) + `,
+  		"reconciliation_id": "` + expected.Data.ReconciliationID + `",
+		"capture_id": "` + expected.Data.CaptureID + `",
+		"reason": "` + expected.Data.Reason + `",
+  		"provider_data": {
+    		"provider_name": "` + expected.Data.ProviderData.ProviderName + `",
+    		"response_code": "` + expected.Data.ProviderData.ResponseCode + `"
+  		}
+	}
+}`
+	r := httptest.NewRequest("POST", "http://nevermind", strings.NewReader(body))
+	r.Header.Set("event-type", eventType)
+	r.Header.Set("x-payments-os-env", expected.XPaymentsOSEnv)
+	r.Header.Set("x-zooz-request-id", expected.XZoozRequestID)
+	r.Header.Set("signature", zooz.WebhookRequestSignature(t, keyProvider, []byte(body), r.Header))
+
+	cb, err := zooz.DecodeWebhookRequest(context.Background(), r, keyProvider)
+	require.NoError(t, err)
+	require.Equal(t, expected, cb)
+}
+
+func TestSignature_AllFields(t *testing.T) {
+	const (
+		privateKey = "test-private-key"
+
+		eventType                      = "payment.authorization.create"
+		id                             = "test-id"
+		created                        = "2018-10-03T05:14:17.196Z"
+		accountID                      = "test-account-id"
+		appID                          = "test-app-id"
+		paymentID                      = "test-app-id"
+		data_ID                        = "test-transaction-id"
+		data_Result_Status             = "Pending"
+		data_Result_Category           = "payment_method_declined"
+		data_Result_SubCategory        = "declined_by_issuing_bank"
+		data_ProviderData_ResponseCode = "124"
+		data_ReconciliationID          = "test-reconciliation-id"
+		data_Amount                    = "42"
+		data_Currency                  = "RUB"
+	)
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(id string) ([]byte, error) {
+		require.Equal(t, appID, id)
+		return []byte(privateKey), nil
+	})
+
+	body := `{
+	"id": "` + id + `",
+    "created": "` + created + `",
+    "account_id": "` + accountID + `",
+    "app_id": "` + appID + `",
+    "payment_id": "` + paymentID + `",
+	"data": {
+		"id": "` + data_ID + `",
+  		"result": {
+			"status": "` + data_Result_Status + `",
+    		"category": "` + data_Result_Category + `",
+    		"sub_category": "` + data_Result_SubCategory + `"
+  		},
+  		"provider_data": {
+    		"response_code": "` + data_ProviderData_ResponseCode + `"
+  		},
+		"reconciliation_id": "` + data_ReconciliationID + `",
+		"amount": ` + data_Amount + `,
+		"currency": "` + data_Currency + `"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", eventType)
+
+	sign, err := zooz.CalculateWebhookSignature(keyProvider, []byte(body), h)
+	require.NoError(t, err)
+	require.Equal(t,
+		signature([]string{
+			eventType,
+			id,
+			accountID,
+			paymentID,
+			created,
+			appID,
+			data_ID,
+			data_Result_Status,
+			data_Result_Category,
+			data_Result_SubCategory,
+			data_ProviderData_ResponseCode,
+			data_ReconciliationID,
+			data_Amount,
+			data_Currency,
+		}, privateKey),
+		sign)
+	require.Equal(t, "3d498ba3149ebd503164bbc7a48feeaea74acc1e5627df5e7dad58a339f7d4af", sign)
+}
+
+func TestSignature_NoAmount(t *testing.T) {
+	const (
+		privateKey = "test-private-key"
+
+		eventType                      = "payment.authorization.create"
+		id                             = "test-id"
+		created                        = "2018-10-03T05:14:17.196Z"
+		accountID                      = "test-account-id"
+		appID                          = "test-app-id"
+		paymentID                      = "test-app-id"
+		data_ID                        = "test-transaction-id"
+		data_Result_Status             = "Pending"
+		data_Result_Category           = "payment_method_declined"
+		data_Result_SubCategory        = "declined_by_issuing_bank"
+		data_ProviderData_ResponseCode = "124"
+		data_ReconciliationID          = "test-reconciliation-id"
+		data_Currency                  = "RUB"
+	)
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(id string) ([]byte, error) {
+		require.Equal(t, appID, id)
+		return []byte(privateKey), nil
+	})
+
+	body := `{
+	"id": "` + id + `",
+    "created": "` + created + `",
+    "account_id": "` + accountID + `",
+    "app_id": "` + appID + `",
+    "payment_id": "` + paymentID + `",
+	"data": {
+		"id": "` + data_ID + `",
+  		"result": {
+			"status": "` + data_Result_Status + `",
+    		"category": "` + data_Result_Category + `",
+    		"sub_category": "` + data_Result_SubCategory + `"
+  		},
+  		"provider_data": {
+    		"response_code": "` + data_ProviderData_ResponseCode + `"
+  		},
+		"reconciliation_id": "` + data_ReconciliationID + `",
+		"currency": "` + data_Currency + `"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", eventType)
+
+	sign, err := zooz.CalculateWebhookSignature(keyProvider, []byte(body), h)
+	require.NoError(t, err)
+	require.Equal(t,
+		signature([]string{
+			eventType,
+			id,
+			accountID,
+			paymentID,
+			created,
+			appID,
+			data_ID,
+			data_Result_Status,
+			data_Result_Category,
+			data_Result_SubCategory,
+			data_ProviderData_ResponseCode,
+			data_ReconciliationID,
+			"", // no amount
+			data_Currency,
+		}, privateKey),
+		sign)
+	require.Equal(t, "330ea79c4154892ec9a57edff161c60a2421bed4872060303c925f41265e0d16", sign)
+}
+
+func TestSignature_ZeroAmount(t *testing.T) {
+	const (
+		privateKey = "test-private-key"
+
+		eventType                      = "payment.authorization.create"
+		id                             = "test-id"
+		created                        = "2018-10-03T05:14:17.196Z"
+		accountID                      = "test-account-id"
+		appID                          = "test-app-id"
+		paymentID                      = "test-app-id"
+		data_ID                        = "test-transaction-id"
+		data_Result_Status             = "Pending"
+		data_Result_Category           = "payment_method_declined"
+		data_Result_SubCategory        = "declined_by_issuing_bank"
+		data_ProviderData_ResponseCode = "124"
+		data_ReconciliationID          = "test-reconciliation-id"
+		data_Currency                  = "RUB"
+	)
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(id string) ([]byte, error) {
+		require.Equal(t, appID, id)
+		return []byte(privateKey), nil
+	})
+
+	body := `{
+	"id": "` + id + `",
+    "created": "` + created + `",
+    "account_id": "` + accountID + `",
+    "app_id": "` + appID + `",
+    "payment_id": "` + paymentID + `",
+	"data": {
+		"id": "` + data_ID + `",
+  		"result": {
+			"status": "` + data_Result_Status + `",
+    		"category": "` + data_Result_Category + `",
+    		"sub_category": "` + data_Result_SubCategory + `"
+  		},
+  		"provider_data": {
+    		"response_code": "` + data_ProviderData_ResponseCode + `"
+  		},
+		"reconciliation_id": "` + data_ReconciliationID + `",
+		"amount": 0,
+		"currency": "` + data_Currency + `"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", eventType)
+
+	sign, err := zooz.CalculateWebhookSignature(keyProvider, []byte(body), h)
+	require.NoError(t, err)
+	require.Equal(t,
+		signature([]string{
+			eventType,
+			id,
+			accountID,
+			paymentID,
+			created,
+			appID,
+			data_ID,
+			data_Result_Status,
+			data_Result_Category,
+			data_Result_SubCategory,
+			data_ProviderData_ResponseCode,
+			data_ReconciliationID,
+			"0",
+			data_Currency,
+		}, privateKey),
+		sign)
+	require.Equal(t, "bb5ce0186b035d21a7dbb23958873082f453acf19b29f7a939cfddf61926acf8", sign)
+}
+
+func TestSignature_MissingFields(t *testing.T) {
+	const (
+		privateKey = "test-private-key"
+
+		eventType                      = "payment.authorization.create"
+		id                             = "test-id"
+		created                        = "2018-10-03T05:14:17.196Z"
+		accountID                      = "test-account-id"
+		appID                          = "test-app-id"
+		paymentID                      = "test-app-id"
+		data_ID                        = "test-transaction-id"
+		data_Result_Status             = "Pending"
+		data_ProviderData_ResponseCode = "124"
+		data_ReconciliationID          = "test-reconciliation-id"
+	)
+
+	keyProvider := zooz.PrivateKeyProviderFunc(func(id string) ([]byte, error) {
+		require.Equal(t, appID, id)
+		return []byte(privateKey), nil
+	})
+
+	body := `{
+	"id": "` + id + `",
+    "created": "` + created + `",
+    "account_id": "` + accountID + `",
+    "app_id": "` + appID + `",
+    "payment_id": "` + paymentID + `",
+	"data": {
+		"id": "` + data_ID + `",
+  		"result": {
+			"status": "` + data_Result_Status + `",
+    		"category": ""
+  		},
+  		"provider_data": {
+    		"response_code": "` + data_ProviderData_ResponseCode + `"
+  		},
+		"reconciliation_id": "` + data_ReconciliationID + `"
+	}
+}`
+	h := http.Header{}
+	h.Set("event-type", eventType)
+
+	sign, err := zooz.CalculateWebhookSignature(keyProvider, []byte(body), h)
+	require.NoError(t, err)
+	require.Equal(t,
+		signature([]string{
+			eventType,
+			id,
+			accountID,
+			paymentID,
+			created,
+			appID,
+			data_ID,
+			data_Result_Status,
+			"", // empty category
+			"", // missing subcategory
+			data_ProviderData_ResponseCode,
+			data_ReconciliationID,
+			"", // no amount
+			"", // no currency
+		}, privateKey),
+		sign)
+	require.Equal(t, "f4a3827af9a1d3a33e33db9dc226e54c676e46295e2e27c3a8115280def4f21c", sign)
+}
+
+//
+//func TestSignature_POS(t *testing.T) {
+//	const (
+//		privateKey = "123456"
+//		expectedSignature = "5f024b177e670949c1c5efc214987467c784aef50807758d22b9d287c8f06ed7"
+//
+//		eventType                      = "payment.authorization.create"
+//		id                             = "ID"
+//		created                        = "2018-10-03T04:58:35.385Z"
+//		accountID                      = "accountID"
+//		appID                          = "appID"
+//		paymentID                      = "paymentID"
+//		data_ID                        = "operationID"
+//		data_Result_Status             = "Succeed"
+//		data_Result_Category           = "category"
+//		data_Result_SubCategory        = "subCategory"
+//		data_ProviderData_ResponseCode = "responseCode"
+//		data_ReconciliationID = "reconciliationID"
+//		data_Amount = "1000"
+//		data_Currency = "RUB"
+//	)
+//
+//	keyProvider := zooz.PrivateKeyProviderFunc(func(id string) ([]byte, error) {
+//		require.Equal(t, appID, id)
+//		return []byte(privateKey), nil
+//	})
+//
+//	body := `{
+//	"id": "` + id + `",
+//    "created": "` + created + `",
+//    "account_id": "` + accountID + `",
+//    "app_id": "` + appID + `",
+//    "payment_id": "` + paymentID + `",
+//	"data": {
+//		"id": "` + data_ID + `",
+//  		"result": {
+//			"status": "` + data_Result_Status + `",
+//    		"category": "` + data_Result_Category + `",
+//    		"sub_category": "` + data_Result_SubCategory + `"
+//  		},
+//  		"provider_data": {
+//    		"response_code": "` + data_ProviderData_ResponseCode + `"
+//  		},
+//		"reconciliation_id": "` + data_ReconciliationID +`",
+//		"amount": ` + data_Amount +`,
+//		"currency": "` + data_Currency +`"
+//	}
+//}`
+//	h := http.Header{}
+//	h.Set("event-type", eventType)
+//
+//	sign, err := zooz.CalculateWebhookSignature(keyProvider, []byte(body), h)
+//	require.NoError(t, err)
+//	require.Equal(t,
+//		signature([]string{
+//			eventType,
+//			id,
+//			accountID,
+//			paymentID,
+//			created,
+//			appID,
+//			data_ID,
+//			data_Result_Status,
+//			data_Result_Category,
+//			data_Result_SubCategory,
+//			data_ProviderData_ResponseCode,
+//			data_ReconciliationID,
+//			data_Amount,
+//			data_Currency,
+//		}, privateKey),
+//		sign)
+//	require.Equal(t, expectedSignature, sign)
+//}
+
+func signature(values []string, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	if _, err := mac.Write([]byte(strings.Join(values, ","))); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(mac.Sum(nil))
+}


### PR DESCRIPTION
Add support for PaymentsOS webhooks.

`DecodeWebhookRequest()` function decodes incoming webhook request into one of callback entities.